### PR TITLE
Refactor/optimize socket persistence

### DIFF
--- a/game/index.js
+++ b/game/index.js
@@ -14,7 +14,7 @@ exports.addNewRoom = async (name) => {
 exports.setSocketHandle = (io) => (_io = io);
 
 //user - user.id, user.socket
-exports.addNewUser = async (userId, userSocket, room) => {
+exports.addNewUser = async (userId, userSocketId, room) => {
   try {
     if (!_rooms.includes(room)) throw new Error('No such room');
 
@@ -22,12 +22,12 @@ exports.addNewUser = async (userId, userSocket, room) => {
     if (dbUser) {
       const looper = _roomLoopMap[room];
       if (looper) {
-        await looper.addUser(dbUser, userSocket);
+        await looper.addUser(dbUser, userSocketId);
         debug('Added user to room');
       } else {
-        const roomEventBridge = new RoomEventBridge(_io);
+        const roomEventBridge = new RoomEventBridge(_io, room);
         const looper = new Looper(room, roomEventBridge);
-        await looper.addUser(dbUser, userSocket);
+        await looper.addUser(dbUser, userSocketId);
         _roomLoopMap[room] = looper;
         debug('Created Looper and add user to room');
       }

--- a/game/looper.js
+++ b/game/looper.js
@@ -21,14 +21,14 @@ class Looper {
     this._roomEventBridge.broadcastRoomState('GE_IDLE');
   }
 
-  addUser(dbUser, socket) {
+  addUser(dbUser, socketId) {
     const foundUser = this._users.find((user) => dbUser.id === user.id);
     if (!foundUser) {
       this._users.push(dbUser);
     } else {
       console.log('user already in room');
     }
-    this._roomEventBridge.updateUserSocket(dbUser.id, socket);
+    this._roomEventBridge.updateUserSocket(dbUser.id, socketId);
     debug('Added new user - ', dbUser);
   }
 

--- a/server.js
+++ b/server.js
@@ -3,7 +3,9 @@ const http = require('http').createServer(app);
 const io = require('socket.io')(http);
 const datastore = require('./datastore');
 const game = require('./game');
-const debug = require('debug')('server');
+const debug = require('debug')('pictionary.server');
+
+const DEFAULT_ROOM = 'main';
 
 game.setSocketHandle(io);
 
@@ -21,12 +23,16 @@ io.on('connection', (socket) => {
     clearInterval(interval);
   });
   
-  socket.on('C_S_LOGIN', async (user) => {
+  socket.on('C_S_LOGIN', async (user, room) => {
     try {
       // log in the user
       const loginResult = await datastore.login(user);
+
+      // Join the socket to the room
+      socket.join(room || DEFAULT_ROOM);
+
       // automatically add the user to the default room
-      await game.addNewUser(user.id, socket, 'main');
+      await game.addNewUser(user.id, socket.id, room || DEFAULT_ROOM);
 
       socket.emit('S_C_LOGIN', loginResult);
 

--- a/server.js
+++ b/server.js
@@ -1,21 +1,26 @@
-var app = require('express')();
-var http = require('http').createServer(app);
-var io = require('socket.io')(http);
-var datastore = require('./datastore/index');
-var game = require('./game/index');
+const app = require('express')();
+const http = require('http').createServer(app);
+const io = require('socket.io')(http);
+const datastore = require('./datastore');
+const game = require('./game');
+const debug = require('debug')('server');
+
+game.setSocketHandle(io);
 
 app.get('/', (req, res) => {
   res.send('<h1>Hello world</h1>');
 });
 
-game.setSocketHandle(io);
-
 io.on('connection', (socket) => {
-  console.log('A user just connected');
+  
+  debug('A user connected');
+  
   let interval = setInterval(() => updateServerTime(socket), 1000);
+  
   socket.on('disconnect', () => {
     clearInterval(interval);
   });
+  
   socket.on('C_S_LOGIN', async (user) => {
     try {
       // log in the user
@@ -24,11 +29,15 @@ io.on('connection', (socket) => {
       await game.addNewUser(user.id, socket, 'main');
 
       socket.emit('S_C_LOGIN', loginResult);
+
     } catch (error) {
-      console.log('Error Logging in - ', error);
+
+      debug('Error Logging in - ', error);
       socket.disconnect();
+
     }
   });
+
 });
 
 const updateServerTime = (socket) => {
@@ -36,5 +45,5 @@ const updateServerTime = (socket) => {
 };
 
 http.listen(3001, () => {
-  console.log('listening on *:3001');
+  debug('listening on *:3001');
 });


### PR DESCRIPTION
- Provision way for clients to join to any room
- Set default room to 'main'
- Pass socket.id to game.addNewUser.
- Store socketId instead of socket against the userId in RoomEventBridge
- Use socket adapter to retrieve the socket using its id
- call `socket.join` to join a socket to a room.
- Remove unwanted mention of `index` in require statements.
- Replace console.log with debug.