### PR TITLE
Minor cleanup in server side code

### DIFF
--- a/events/index.js
+++ b/events/index.js
@@ -9,11 +9,7 @@ class RoomEventBridge extends EventEmitter {
     this._room = room;
   }
 
-  setIO(io) {
-    this._io = io;
-  }
-
-  getClientSocketInRoom(socketId) {
+  _getClientSocketInRoom(socketId) {
     if (!this._io || !this._io.sockets.adapter.rooms[this._room]) return null;
 
     const clients = this._io.sockets.adapter.rooms[this._room].sockets;
@@ -36,7 +32,7 @@ class RoomEventBridge extends EventEmitter {
   // Add socket, or update socket when there is a reconnection?
   updateUserSocket(userId, socketId) {
     this._userSocketIdMap[userId] = socketId;
-    let clientSocket = this.getClientSocketInRoom(socketId);
+    let clientSocket = this._getClientSocketInRoom(socketId);
     debug("Client socket found", clientSocket.id);
     if (clientSocket) {
       clientSocket.on("GE_NEW_GUESS", (args) => {
@@ -66,7 +62,7 @@ class RoomEventBridge extends EventEmitter {
 
   sendWordToPlayer(userId, word) {
     debug("send word to player: ", userId, word);
-    const clientSocket = this.getClientSocketInRoom(
+    const clientSocket = this._getClientSocketInRoom(
       this._userSocketIdMap[userId]
     );
     if (clientSocket) clientSocket.emit("GE_NEW_WORD", word);

--- a/game/index.js
+++ b/game/index.js
@@ -22,7 +22,6 @@ exports.addNewUser = async (userId, userSocketId, room) => {
     if (dbUser) {
       const looper = _roomLoopMap[room];
       if (looper) {
-        looper.getEventBridge().setIO(_io);
         await looper.addUser(dbUser, userSocketId);
         debug('Added user to room');
       } else {

--- a/game/looper.js
+++ b/game/looper.js
@@ -28,10 +28,6 @@ class Looper {
     });
   }
 
-  getEventBridge() {
-    return this._roomEventBridge;
-  }
-
   addUser(dbUser, socketId) {
     const foundUser = this._users.find((user) => dbUser.id === user.id);
     if (!foundUser) {
@@ -103,7 +99,7 @@ class Looper {
     this._currentWord = 'BANANA';
 
     // emit round started
-    this._roomEventBridge.broadcastRoomState('GE_NEW_ROUND', { round: this._roundsLeft, total: this._totalRounds });
+    this._roomEventBridge.broadcastRoomState('GE_NEW_ROUND', { round: this._roundsLeft, total: this._totalRounds, currentDrawingUser });
     this._roomEventBridge.sendWordToPlayer(currentDrawingUser.id, this._currentWord);
 
     // Assign other users to guess


### PR DESCRIPTION
### Handling IO Object in looper
- Remove calling `setIO` if looper is already available
- it is a global object and will be available as long as the server is running
- Remove `setIO` method definition
- Rename `getClientSocketInRoom` to `_getClientSocketInRoom`
- Broadcast  currentDrawingUser to clients

### Evaluate the number of users when starting next round
- There is a 5 second timeout between rounds
- Users can drop between two rounds
- Before starting next round, check number of users
- Start round only if #users > 1
- Else stop the game and announce winner.
- Create and reuse `stopGame` method.