### PR TITLE
Prevent scroll of page and preserve scale in mobile

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -37,6 +37,10 @@ function App() {
   }, [showGuessBox]);
 
   useEffect(() => {
+    document.body.addEventListener('touchmove', function(e){ e.preventDefault(); });
+  }, []);
+  
+  useEffect(() => {
     const io = socket('http://192.168.1.5:3001');
     io.on('connect', () => {
       const user = {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -37,10 +37,6 @@ function App() {
   }, [showGuessBox]);
 
   useEffect(() => {
-    document.body.addEventListener('touchmove', function(e){ e.preventDefault(); });
-  }, []);
-  
-  useEffect(() => {
     const io = socket('http://localhost:3001');
     io.on('connect', () => {
       const user = {
@@ -146,6 +142,12 @@ function App() {
     });
     return renderUsers;
   };
+
+  useEffect(() => {
+    document.body.addEventListener('touchmove', function (e) {
+      e.preventDefault();
+    });
+  }, []);
 
   return (
     <div className="App">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -41,7 +41,7 @@ function App() {
   }, []);
   
   useEffect(() => {
-    const io = socket('http://192.168.1.5:3001');
+    const io = socket('http://localhost:3001');
     io.on('connect', () => {
       const user = {
         id: `player${+new Date()}`,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
Prevent Scroll and preserve scale in Mobile.

### Description
<!--- Describe your changes in detail -->
 - Listen to touchmove event in document.body and prevent scroll
 - Add user-scalable=no in viewport meta tag.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Its annoying in mobile where a user can accidentally zoom in  or out and even scroll the page.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested on my personal phone (Samsung Galaxy) on firefox for android.
### Screenshots, if any

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
