### PR TITLE
Add on-screen keyboard for entering guess words

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11473,6 +11473,11 @@
         "workbox-webpack-plugin": "4.3.1"
       }
     },
+    "react-simple-keyboard": {
+      "version": "2.3.33",
+      "resolved": "https://registry.npmjs.org/react-simple-keyboard/-/react-simple-keyboard-2.3.33.tgz",
+      "integrity": "sha512-IH8WD1Wops5851+UdJuxxVikatVl+B0yL0e+A/X86KSLmLp3avad8ME2h4XsjOEJxMUCSfGPthjq++XxZzTFeA=="
+    },
     "react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "react-countdown-clock": "^2.7.0",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
+    "react-simple-keyboard": "^2.3.33",
     "socket.io-client": "^2.3.0"
   },
   "scripts": {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -77,3 +77,9 @@
   z-index: 100;
   padding: inherit;
 }
+
+.keyboardContainer {
+  display: flex;
+  justify-content: space-around;
+  padding: 20px 35px 20px 20px;
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Added on-screen keyboard for users to enter their guess

### Description
<!--- Describe your changes in detail -->
- Install react-simple-keyboard module with npm
- Modify the layout to include only alphabets and enter key
- Sync the edit text and onscreen keyboard input

TODO:
 - Handle layout changes for small screens
-  Disable editing for text field in mobile screens.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses #22 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Screenshots, if any

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
