### PR TITLE
Fix keyboardRef crash when keyboard is not visible

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -187,7 +187,9 @@ function App () {
 
   const resetGuess = () => {
     setGuess('');
-    keyboardRef.current.setInput('');
+    if (keyboardRef.current) {
+      keyboardRef.current.setInput('');
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
- onscreen keyboard is not visible in bigger screens.
- keyboardRef.current shall be null in those cases.
- Add a check before calling setInput

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
